### PR TITLE
feat: adds basic support for XDG dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ set -g @tmux-which-key-disable-autobuild=1
 set -g @plugin 'alexwforsythe/tmux-which-key'
 ```
 
-##### @tmux-which-key-enable-xdg-dirs
+##### @tmux-which-key-xdg-enable
 
 Enables the use of XDG directories for the configuration and init files.
 
@@ -272,7 +272,7 @@ The allows the plugin to also be used with immutable or declarative operating
 systems.
 
 ```tmux
-set -g @tmux-which-key-enable-xdg-dirs=1
+set -g @tmux-which-key-xdg-enable=1
 # ...
 set -g @plugin 'alexwforsythe/tmux-which-key'
 ```
@@ -311,7 +311,7 @@ in {
     {
       plugin = tmux-which-key;
       extraConfig = ''
-        set -g @tmux-which-key-enable-xdg-dirs 1;
+        set -g @tmux-which-key-xdg-enable 1;
       '';
     }
   ];

--- a/README.md
+++ b/README.md
@@ -255,11 +255,21 @@ set -g @plugin 'alexwforsythe/tmux-which-key'
 
 ##### @tmux-which-key-enable-xdg-dirs
 
-Moves the configuration file to
-`$XDG_CONFIG_HOME/tmux-plugins/tmux-which-key/config.yaml`
+Enables the use of XDG directories for the configuration and init files.
+
+With this option enabled, the following option also becomes available:
+
+```tmux
+# relative path from $XDG_*_HOME for files
+set -g @tmux-which-key-xdg-plugin-path=tmux/plugins/tmux-which-key # default
+```
+
+Enabling moves the configuration file to
+`$XDG_CONFIG_HOME/<@tmux-which-key-xdg-plugin-path>/config.yaml`
 and the init file to
-`$XDG_DATA_HOME/tmux-plugins/tmux-which-key/init.tmux`.
-Allows the plugin to be used with immutable or declarative operating systems.
+`$XDG_DATA_HOME/<@tmux-which-key-xdg-plugin-path>/init.tmux`.
+The allows the plugin to also be used with immutable or declarative operating
+systems.
 
 ```tmux
 set -g @tmux-which-key-enable-xdg-dirs=1
@@ -281,7 +291,7 @@ set -g @plugin 'alexwforsythe/tmux-which-key'
     pkgs.tmuxPlugins.mkTmuxPlugin
     {
       pluginName = "tmux-which-key";
-      version = "<short commit hash>";
+      version = "2024-01-10";
       src = pkgs.fetchFromGitHub {
         owner = "alexwforsythe";
         repo = "tmux-which-key";
@@ -292,7 +302,7 @@ set -g @plugin 'alexwforsythe/tmux-which-key'
     };
 in {
   xdg.configFile = {
-    "tmux-plugins/tmux-which-key/config.yaml".text = lib.generators.toYAML {} {
+    "tmux/plugins/tmux-which-key/config.yaml".text = lib.generators.toYAML {} {
       command_alias_start_index = 200;
       # rest of config here
     };

--- a/README.md
+++ b/README.md
@@ -255,27 +255,27 @@ set -g @plugin 'alexwforsythe/tmux-which-key'
 
 ##### @tmux-which-key-xdg-enable
 
-Enables the use of XDG directories for the configuration and init files.
+Changes the location of configuration and init files to use XDG directories.
+By default, these paths are used instead of this plugin's installation
+directory:
 
-With this option enabled, the following option also becomes available:
+- `$XDG_CONFIG_HOME/tmux/plugins/tmux-which-key/config.yaml`
+- `$XDG_DATA_HOME/tmux/plugins/tmux-which-key/init.tmux`.
 
-```tmux
-# relative path from $XDG_*_HOME for files
-set -g @tmux-which-key-xdg-plugin-path=tmux/plugins/tmux-which-key # default
-```
-
-Enabling moves the configuration file to
-`$XDG_CONFIG_HOME/<@tmux-which-key-xdg-plugin-path>/config.yaml`
-and the init file to
-`$XDG_DATA_HOME/<@tmux-which-key-xdg-plugin-path>/init.tmux`.
-The allows the plugin to also be used with immutable or declarative operating
-systems.
+The relative path from `XDG_*_HOME` can be changed using the
+`@tmux-which-key-xdg-plugin-path` option for additional customization.
 
 ```tmux
 set -g @tmux-which-key-xdg-enable=1
+set -g @tmux-which-key-xdg-plugin-path=tmux/plugins/tmux-which-key # default
+
 # ...
+
 set -g @plugin 'alexwforsythe/tmux-which-key'
 ```
+
+This allows the plugin to also be used with immutable or declarative operating
+systems.
 
 <!-- markdownlint-disable MD033 -->
 <details>

--- a/README.md
+++ b/README.md
@@ -253,6 +253,64 @@ set -g @tmux-which-key-disable-autobuild=1
 set -g @plugin 'alexwforsythe/tmux-which-key'
 ```
 
+##### @tmux-which-key-enable-xdg-dirs
+
+Moves the configuration file to
+`$XDG_CONFIG_HOME/tmux-plugins/tmux-which-key/config.yaml`
+and the init file to
+`$XDG_DATA_HOME/tmux-plugins/tmux-which-key/init.tmux`.
+Allows the plugin to be used with immutable or declarative operating systems.
+
+```tmux
+set -g @tmux-which-key-enable-xdg-dirs=1
+# ...
+set -g @plugin 'alexwforsythe/tmux-which-key'
+```
+
+<!-- markdownlint-disable MD033 -->
+<details>
+<summary>Example Home Manager Nix Config</summary>
+
+```nix
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  tmux-which-key =
+    pkgs.tmuxPlugins.mkTmuxPlugin
+    {
+      pluginName = "tmux-which-key";
+      version = "<short commit hash>";
+      src = pkgs.fetchFromGitHub {
+        owner = "alexwforsythe";
+        repo = "tmux-which-key";
+        rev = "<commit hash>";
+        sha256 = lib.fakeSha256;
+      };
+      rtpFilePath = "plugin.sh.tmux";
+    };
+in {
+  xdg.configFile = {
+    "tmux-plugins/tmux-which-key/config.yaml".text = lib.generators.toYAML {} {
+      command_alias_start_index = 200;
+      # rest of config here
+    };
+  };
+  programs.tmux.plugins = [
+    {
+      plugin = tmux-which-key;
+      extraConfig = ''
+        set -g @tmux-which-key-enable-xdg-dirs 1;
+      '';
+    }
+  ];
+}
+```
+
+</details>
+<!-- markdownlint-enable MD033 -->
+
 ### Manual
 
 You can customize the action menu by editing `plugin/init.tmux` directly.

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -56,6 +56,7 @@ case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
         case "$xdg_config_path" in
             ../*)
                 echo "[tmux-which-key] XDG_CONFIG_HOME plugin path is outside of HOME: $HOME/$xdg_config_path"
+                exit 1
                 ;;
         esac
         make_xdg_path "$HOME/$xdg_config_path"
@@ -66,6 +67,7 @@ case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
         case "$xdg_data_path" in
             ../*)
                 echo "[tmux-which-key] XDG_DATA_HOME plugin path is outside of HOME: $HOME/$xdg_data_path"
+                exit 1
                 ;;
         esac
         make_xdg_path "$HOME/$xdg_data_path"

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -15,7 +15,7 @@ plugin_dir="$root_dir/plugin"
 init_file="$plugin_dir/init.tmux"
 
 # XDG
-case "$(tmux show-option -gvq @tmux-which-key-enable-xdg-dirs)" in
+case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
     1 | true)
         if [ -z "$XDG_CONFIG_HOME" ]; then
             echo "[tmux-which-key] XDG_CONFIG_HOME is not set"

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -14,6 +14,19 @@ config_file="$root_dir/config.yaml"
 plugin_dir="$root_dir/plugin"
 init_file="$plugin_dir/init.tmux"
 
+# XDG
+case "$(tmux show-option -gvq @tmux-which-key-enable-xdg-dirs)" in
+    1 | true)
+        root_dir="$(dirname "$(readlink -f "$0")")"
+        plugin_dir="$root_dir/plugin"
+        # do not create XDG dirs if they don't exist
+        (cd "$XDG_CONFIG_HOME" && mkdir -p tmux/plugins/tmux-which-key)
+        (cd "$XDG_DATA_HOME" && mkdir -p tmux/plugins/tmux-which-key)
+        config_file="$XDG_CONFIG_HOME/tmux/plugins/tmux-which-key/config.yaml"
+        init_file="$XDG_DATA_HOME/tmux/plugins/tmux-which-key/init.tmux"
+        ;;
+esac
+
 # Copy the default configs to the root directory if they don't exist yet. The
 # root files are gitignored so users can customize them without breaking git
 # updates.
@@ -26,15 +39,15 @@ fi
 
 # If enabled, rebuild the menu from the user config.
 case "$(tmux show-option -gvq @tmux-which-key-disable-autobuild)" in
-1 | true) ;;
-*)
-    echo "[tmux-which-key] Rebuilding menu ..."
-    if command -v python3 >/dev/null; then
-        "$plugin_dir/build.py" "$config_file" "$init_file"
-    else
-        echo "[tmux-which-key] python3 not found"
-    fi
-    ;;
+    1 | true) ;;
+    *)
+        echo "[tmux-which-key] Rebuilding menu ..."
+        if command -v python3 >/dev/null; then
+            "$plugin_dir/build.py" "$config_file" "$init_file"
+        else
+            echo "[tmux-which-key] python3 not found"
+        fi
+        ;;
 esac
 
 # Load the plugin.

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -19,11 +19,11 @@ case "$(tmux show-option -gvq @tmux-which-key-enable-xdg-dirs)" in
     1 | true)
         root_dir="$(dirname "$(readlink -f "$0")")"
         plugin_dir="$root_dir/plugin"
-        # do not create XDG dirs if they don't exist
-        (cd "$XDG_CONFIG_HOME" && mkdir -p tmux/plugins/tmux-which-key)
-        (cd "$XDG_DATA_HOME" && mkdir -p tmux/plugins/tmux-which-key)
-        config_file="$XDG_CONFIG_HOME/tmux/plugins/tmux-which-key/config.yaml"
-        init_file="$XDG_DATA_HOME/tmux/plugins/tmux-which-key/init.tmux"
+        # do not create base XDG dirs if they don't exist
+        (cd "$XDG_CONFIG_HOME" && mkdir -p tmux-plugins/tmux-which-key)
+        (cd "$XDG_DATA_HOME" && mkdir -p tmux-plugins/tmux-which-key)
+        config_file="$XDG_CONFIG_HOME/tmux-plugins/tmux-which-key/config.yaml"
+        init_file="$XDG_DATA_HOME/tmux-plugins/tmux-which-key/init.tmux"
         ;;
 esac
 

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -38,7 +38,7 @@ make_xdg_path() {
 case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
     1 | true)
         if [ -z "$HOME" ]; then
-            echo "[tmux-which-key] HOME is not set.  XDG support is limited to users only".
+            echo "[tmux-which-key] HOME is not set.  XDG support is limited to users only."
             exit 1
         fi
 

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -15,32 +15,68 @@ plugin_dir="$root_dir/plugin"
 init_file="$plugin_dir/init.tmux"
 
 # XDG
+
+# create an XDG path and set the spec's default permissions of 0700 to newly
+# created directories only
+make_xdg_path() {
+    OLDIFS=$IFS
+    IFS='/'
+    current_dir=""
+    # walk the path to create each directory if it doesn't exist
+    for dir in $1; do
+        current_dir="$current_dir/$dir"
+        # only create the directory and apply the mode it doesn't exist
+        if [ ! -d "$current_dir/$dir" ]; then
+            # shellcheck disable=SC2174
+            # applying the mode to the deepest directory is intentional
+            mkdir -m 0700 -p "$current_dir"
+        fi
+    done
+    IFS=$OLDIFS
+}
+
 case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
     1 | true)
-        if [ -z "$XDG_CONFIG_HOME" ]; then
-            echo "[tmux-which-key] XDG_CONFIG_HOME is not set"
+        if [ -z "$HOME" ]; then
+            echo "[tmux-which-key] HOME is not set.  XDG support is limited to users only".
             exit 1
         fi
-        if [ ! -d "$XDG_CONFIG_HOME" ]; then
-            echo "[tmux-which-key] XDG_CONFIG_HOME: $XDG_CONFIG_HOME does not exist"
-            exit 1
-        fi
-        if [ -z "$XDG_DATA_HOME" ]; then
-            echo "[tmux-which-key] XDG_DATA_HOME is not set"
-            exit 1
-        fi
-        if [ ! -d "$XDG_DATA_HOME" ]; then
-            echo "[tmux-which-key] XDG_CONFIG_HOME: $XDG_DATA_HOME does not exist"
-            exit 1
-        fi
+
+        # use XDG spec's default directories if not set
+        XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+        XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+
+        # get relative XDG path for the plugin or use the default
         xdg_plugin_path=$(tmux show-option -gvq @tmux-which-key-xdg-plugin-path)
         xdg_plugin_path=${xdg_plugin_path:-tmux/plugins/tmux-which-key}
-        mkdir -p "$XDG_CONFIG_HOME/$xdg_plugin_path"
-        mkdir -p "$XDG_DATA_HOME/$xdg_plugin_path"
-        config_file="$XDG_CONFIG_HOME/$xdg_plugin_path/config.yaml"
-        init_file="$XDG_DATA_HOME/$xdg_plugin_path/init.tmux"
+
+        # create the config path if it doesn't exist, ensure it is inside
+        # $HOME, and simplify the path
+        xdg_config_path="$(realpath --relative-to="$HOME" "$XDG_CONFIG_HOME")/$xdg_plugin_path"
+        case "$xdg_config_path" in
+            ../*)
+                echo "XDG_CONFIG_HOME plugin path is outside of HOME: $HOME/$xdg_config_path"
+                ;;
+        esac
+        make_xdg_path "$HOME/$xdg_config_path"
+
+        # create the data path if it doesn't exist, ensure it is inside
+        # $HOME, and simplify the path
+        xdg_data_path="$(realpath --relative-to="$HOME" "$XDG_DATA_HOME")/$xdg_plugin_path"
+        case "$xdg_data_path" in
+            ../*)
+                echo "XDG_DATA_HOME plugin path is outside of HOME: $HOME/$xdg_data_path"
+                ;;
+        esac
+        make_xdg_path "$HOME/$xdg_data_path"
+
+        # use the XDG paths
+        config_file="$xdg_config_path/config.yaml"
+        init_file="$xdg_data_path/init.tmux"
         ;;
 esac
+
+# /XDG
 
 # Copy the default configs to the root directory if they don't exist yet. The
 # root files are gitignored so users can customize them without breaking git

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -55,7 +55,7 @@ case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
         xdg_config_path="$(realpath --relative-to="$HOME" "$XDG_CONFIG_HOME")/$xdg_plugin_path"
         case "$xdg_config_path" in
             ../*)
-                echo "XDG_CONFIG_HOME plugin path is outside of HOME: $HOME/$xdg_config_path"
+                echo "[tmux-which-key] XDG_CONFIG_HOME plugin path is outside of HOME: $HOME/$xdg_config_path"
                 ;;
         esac
         make_xdg_path "$HOME/$xdg_config_path"
@@ -65,7 +65,7 @@ case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
         xdg_data_path="$(realpath --relative-to="$HOME" "$XDG_DATA_HOME")/$xdg_plugin_path"
         case "$xdg_data_path" in
             ../*)
-                echo "XDG_DATA_HOME plugin path is outside of HOME: $HOME/$xdg_data_path"
+                echo "[tmux-which-key] XDG_DATA_HOME plugin path is outside of HOME: $HOME/$xdg_data_path"
                 ;;
         esac
         make_xdg_path "$HOME/$xdg_data_path"

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -17,11 +17,28 @@ init_file="$plugin_dir/init.tmux"
 # XDG
 case "$(tmux show-option -gvq @tmux-which-key-enable-xdg-dirs)" in
     1 | true)
-        # do not create base XDG dirs if they don't exist
-        (cd "$XDG_CONFIG_HOME" && mkdir -p tmux-plugins/tmux-which-key)
-        (cd "$XDG_DATA_HOME" && mkdir -p tmux-plugins/tmux-which-key)
-        config_file="$XDG_CONFIG_HOME/tmux-plugins/tmux-which-key/config.yaml"
-        init_file="$XDG_DATA_HOME/tmux-plugins/tmux-which-key/init.tmux"
+        if [ -z "$XDG_CONFIG_HOME" ]; then
+            echo "[tmux-which-key] XDG_CONFIG_HOME is not set"
+            exit 1
+        fi
+        if [ ! -d "$XDG_CONFIG_HOME" ]; then
+            echo "[tmux-which-key] XDG_CONFIG_HOME: $XDG_CONFIG_HOME does not exist"
+            exit 1
+        fi
+        if [ -z "$XDG_DATA_HOME" ]; then
+            echo "[tmux-which-key] XDG_DATA_HOME is not set"
+            exit 1
+        fi
+        if [ ! -d "$XDG_DATA_HOME" ]; then
+            echo "[tmux-which-key] XDG_CONFIG_HOME: $XDG_DATA_HOME does not exist"
+            exit 1
+        fi
+        xdg_plugin_path=$(tmux show-option -gvq @tmux-which-key-xdg-plugin-path)
+        xdg_plugin_path=${xdg_plugin_path:-tmux/plugins/tmux-which-key}
+        mkdir -p "$XDG_CONFIG_HOME/$xdg_plugin_path"
+        mkdir -p "$XDG_DATA_HOME/$xdg_plugin_path"
+        config_file="$XDG_CONFIG_HOME/$xdg_plugin_path/config.yaml"
+        init_file="$XDG_DATA_HOME/$xdg_plugin_path/init.tmux"
         ;;
 esac
 

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -17,8 +17,6 @@ init_file="$plugin_dir/init.tmux"
 # XDG
 case "$(tmux show-option -gvq @tmux-which-key-enable-xdg-dirs)" in
     1 | true)
-        root_dir="$(dirname "$(readlink -f "$0")")"
-        plugin_dir="$root_dir/plugin"
         # do not create base XDG dirs if they don't exist
         (cd "$XDG_CONFIG_HOME" && mkdir -p tmux-plugins/tmux-which-key)
         (cd "$XDG_DATA_HOME" && mkdir -p tmux-plugins/tmux-which-key)

--- a/plugin.sh.tmux
+++ b/plugin.sh.tmux
@@ -71,8 +71,8 @@ case "$(tmux show-option -gvq @tmux-which-key-xdg-enable)" in
         make_xdg_path "$HOME/$xdg_data_path"
 
         # use the XDG paths
-        config_file="$xdg_config_path/config.yaml"
-        init_file="$xdg_data_path/init.tmux"
+        config_file="$HOME/$xdg_config_path/config.yaml"
+        init_file="$HOME/$xdg_data_path/init.tmux"
         ;;
 esac
 


### PR DESCRIPTION
Adds some additional control over the config and init file locations.

When installed with an immutable/declarative OS, the plugin directory is read-only.

Could probably use some more rigid assignments of those paths for full XDG support (see the discussion at https://github.com/tmux-plugins/tmux-resurrect/issues/348).

When I get a moment, I can dig in some more, but for now I wanted to share some minimal changes that make this plugin usable with Nix.