### PR TITLE
fix(gitmodules): noninteractive install with tpm sometimes hangs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "plugin/pyyaml"]
 	path = plugin/pyyaml
-	url = git@github.com:yaml/pyyaml.git
+	url = https://github.com/yaml/pyyaml.git


### PR DESCRIPTION
The noninteractive installs can hang if the computer has never connected to GitHub previously via SSH. This causes the _"authenticity of host cannot be established warning"_ error upon which the user is interactively prompted whether to accept or reject the host key. 

Unauthenticated hosts is not a problem with HTTPS.

Relates to tmux-plugins/tpm#219