### PR TITLE
feat: adds flake.nix with home manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ with a wizard to complete the installation.
 
 <!-- markdownlint-enable MD033 -->
 
-### Nix with Home Manager Flake Installation
+### Nix with home manager flake installation
 
 <!-- markdownlint-disable MD033 -->
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719468428,
+        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "A plugin for tmux that allows users to select actions from a customizable popup menu";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    inherit (nixpkgs) lib;
+    systems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "aarch64-linux"
+    ];
+    pkgsFor = lib.genAttrs systems (system: import nixpkgs {inherit system;});
+    forAllSystems = f: lib.genAttrs systems (system: f pkgsFor.${system});
+    version = self.sourceInfo.shortRev or self.sourceInfo.dirtyShortRev;
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (pkgs: {
+      default = pkgs.callPackage ./nix {inherit version;};
+    });
+
+    homeManagerModules.default = import ./nix/home-manager.nix self;
+
+    overlays.default = final: prev: {
+      tmuxPlugins =
+        prev.tmuxPlugins
+        // {
+          tmux-which-key = final.default;
+        };
+    };
+
+    apps = forAllSystems (pkgs: let
+      defaultConfig = import ./nix/generate-config.nix {
+        inherit lib pkgs;
+      };
+    in {
+      generate-config = {
+        name = "generate-config";
+        type = "app";
+        program = "${pkgs.writeShellScriptBin "generate-config" ''
+          echo '${lib.generators.toPretty {} defaultConfig}';
+        ''}/bin/generate-config";
+      };
+    });
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  check-jsonschema,
   python3,
   tmuxPlugins,
   version,
@@ -8,11 +9,11 @@
 tmuxPlugins.mkTmuxPlugin {
   inherit version;
   pluginName = "tmux-which-key";
-  propagatedBuildInputs = [python3];
+  propagatedBuildInputs = [check-jsonschema (python3.withPackages (ps: with ps; [pyyaml]))];
   src = lib.cleanSource ../.;
   preInstall = ''
     rm -rf plugin/pyyaml
-    cp -r ${python3.pkgs.pyyaml.src} plugin/pyyaml
+    ln -s ${python3.pkgs.pyyaml.src} plugin/pyyaml
   '';
   rtpFilePath = "plugin.sh.tmux";
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  python3,
+  tmuxPlugins,
+  version,
+  ...
+}:
+tmuxPlugins.mkTmuxPlugin {
+  inherit version;
+  pluginName = "tmux-which-key";
+  propagatedBuildInputs = [python3];
+  src = lib.cleanSource ../.;
+  preInstall = ''
+    rm -rf plugin/pyyaml
+    cp -r ${python3.pkgs.pyyaml.src} plugin/pyyaml
+  '';
+  rtpFilePath = "plugin.sh.tmux";
+}

--- a/nix/generate-config.nix
+++ b/nix/generate-config.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  pkgs,
+}: let
+  fromYaml = file: let
+    convertedJson = pkgs.runCommandNoCC "converted.json" {} ''
+      ${lib.getExe pkgs.yj} < ${file} > $out
+    '';
+  in
+    builtins.fromJSON (builtins.readFile "${convertedJson}");
+in
+  fromYaml ../config.example.yaml

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -51,7 +51,9 @@ in {
       pkgs.runCommandNoCC "init.tmux" {
         nativeBuildInputs = cfg.package.propagatedBuildInputs;
       } ''
-        echo '${configYaml}' > config.yaml
+        echo '# yaml-language-server: $schema=config.schema.yaml' > config.yaml
+        echo '${configYaml}' >> config.yaml
+        check-jsonschema -v --schemafile "${cfg.package}/share/tmux-plugins/tmux-which-key/config.schema.yaml" config.yaml
         python3 "${cfg.package}/share/tmux-plugins/tmux-which-key/plugin/build.py" \
           config.yaml $out
         rm config.yaml

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,76 @@
+self: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.tmux.tmux-which-key;
+  pluginPath = "tmux-plugins/tmux-which-key";
+  defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in {
+  options.programs.tmux.tmux-which-key = {
+    enable = lib.mkEnableOption "tmux-which-key";
+
+    package = lib.mkOption {
+      type = with lib.types; nullOr package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "inputs.tmux-which-key.packages.${pkgs.stdenv.hostPlatform.system}.default";
+      description = ''
+        The tmux-which-key package to use.
+
+        By default, this option will use the `packages.default` as exposed by this flake.
+      '';
+    };
+
+    settings = lib.mkOption rec {
+      type = with lib.types; let
+        valueType =
+          nullOr (oneOf [
+            bool
+            int
+            float
+            str
+            path
+            (attrsOf valueType)
+            (listOf valueType)
+          ])
+          // {
+            description = "tmux-which-key configuration value";
+          };
+      in
+        valueType;
+      default = import ./generate-config.nix {inherit lib pkgs;};
+      description = "tmux-which-key plugin configuration";
+      example = default;
+    };
+  };
+
+  config = let
+    configYaml = lib.generators.toYAML {} cfg.settings;
+    configTmux =
+      pkgs.runCommandNoCC "init.tmux" {
+        nativeBuildInputs = cfg.package.propagatedBuildInputs;
+      } ''
+        echo '${configYaml}' > config.yaml
+        python3 "${cfg.package}/share/tmux-plugins/tmux-which-key/plugin/build.py" \
+          config.yaml $out
+        rm config.yaml
+      '';
+  in
+    lib.mkIf cfg.enable {
+      xdg = {
+        configFile."${pluginPath}/config.yaml".text = configYaml;
+        dataFile."${pluginPath}/init.tmux".source = configTmux;
+      };
+      programs.tmux.plugins = [
+        {
+          plugin = cfg.package;
+          extraConfig = ''
+            set -g @tmux-which-key-xdg-enable 1;
+            set -g @tmux-which-key-disable-autobuild 1
+            set -g @tmux-which-key-xdg-plugin-path "${pluginPath}"
+          '';
+        }
+      ];
+    };
+}


### PR DESCRIPTION
Removes the original example Nix configuration I had contributed and adds a `flake.nix` to the repo with more thorough installation steps.  A `flake.nix` in the repository allows Nix users to install directly from GitHub.

This is in response to the new comments on https://github.com/alexwforsythe/tmux-which-key/issues/2#issuecomment-2192905818.

The following files are added:

- `flake.nix` - Entry point that the Nix package manager looks for when installing from GitHub.
- `flake.lock` - Nix is declarative and enforces pinned dependencies.  This shouldn't need to be updated very often if at all.  The only dependency is on `nixpkgs` and the instructions have the user override it with whatever version they use.
- `nix/default.nix` - Creates the Nix plugin package.
- `nix/generate-config.nix` - Helper to convert YAML configurations into a Nix source file.
- `nix/home-manager.nix` - Nix is typically focused on system configurations whereas home manager focuses on per-user configurations.  This adds options the user can use to install and configure the plugin with Nix expressions.  It handles converting Nix expressions back into a YAML configuration and running `build.py` to produce the final tmux configuration.

I updated `README.md` by removing the old example and put in more thorough examples using the `flake.nix`.  I also corrected a few linting errors for indented code blocks under a list and HTML elements.

I'm also happy to be a CODEOWNER for these files to keep them maintained if wished.  If you want me to add, just let me know!