### PR TITLE
Fix rename session command

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -220,7 +220,7 @@ items:
         command: new
       - name: Rename
         key: r
-        command: rename
+        command: command-prompt -I "rename-session "
   - name: +Client
     key: C
     menu:

--- a/plugin/init.example.tmux
+++ b/plugin/init.example.tmux
@@ -97,7 +97,7 @@ Paste "p" pasteb'
 set -g @wk_menu_sessions \
 'Choose "s" "choose-tree -Zs" \
 New "N" new \
-Rename "r" rename'
+Rename "r" 'command-prompt -I "rename-session "'
 
 set -g @wk_menu_plugins \
 'Install "i" "run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/install_plugins" \

--- a/which-key.sh
+++ b/which-key.sh
@@ -116,7 +116,7 @@ Sessions)
     show_menu \
         Choose s 'choose-tree -Zs' \
         New N new \
-	Rename r 'command-prompt -I "rename-session "'
+        Rename r 'command-prompt -I "rename-session "'
     ;;
 Client)
     show_menu \

--- a/which-key.sh
+++ b/which-key.sh
@@ -116,7 +116,7 @@ Sessions)
     show_menu \
         Choose s 'choose-tree -Zs' \
         New N new \
-        Rename r rename
+	Rename r 'command-prompt -I "rename-session "'
     ;;
 Client)
     show_menu \


### PR DESCRIPTION
The current command for renaming session is not working so I fixed it.

Before:
![Screenshot_23-Nov_11-51-57_foot](https://github.com/user-attachments/assets/8bb4376a-cc26-4bf6-8a96-18589d69f105)
After:
![Screenshot_23-Nov_11-47-49_foot](https://github.com/user-attachments/assets/06d39843-1f40-4b30-a978-8d5f1e315a6f)