### PR TITLE
docs: fix incorrect tmux configurations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ plugin's impact on tmux startup time, you can disable this behavior by adding
 this to your `~/.tmux.conf` **before** loading the plugin:
 
 ```tmux
-set -g @tmux-which-key-disable-autobuild=1
+set -g @tmux-which-key-disable-autobuild 1
 # ...
 set -g @plugin 'alexwforsythe/tmux-which-key'
 ```
@@ -283,8 +283,8 @@ The relative path from `XDG_*_HOME` can be changed using the
 `@tmux-which-key-xdg-plugin-path` option for additional customization.
 
 ```tmux
-set -g @tmux-which-key-xdg-enable=1
-set -g @tmux-which-key-xdg-plugin-path=tmux/plugins/tmux-which-key # default
+set -g @tmux-which-key-xdg-enable 1
+set -g @tmux-which-key-xdg-plugin-path tmux/plugins/tmux-which-key # default
 
 # ...
 


### PR DESCRIPTION
Awesome project! I just installed it and configured it by following your README document. I realized that there are some incorrect configurations that cannot work correctly and will cause errors in the README file.

An example error:
```
~/.tmux.conf:30:  Empty value
```

References:
- https://man7.org/linux/man-pages/man1/tmux.1.html#:~:text=are%20as%20follows%3A-,set%2Doption%20%5B,-%2DaFgopqsuUw%5D%20%5B%2Dt
